### PR TITLE
Add service overwrite

### DIFF
--- a/library/Businessprocess/BpConfig.php
+++ b/library/Businessprocess/BpConfig.php
@@ -460,16 +460,17 @@ class BpConfig
         return array_key_exists($name, $this->root_nodes);
     }
 
-    public function createService($host, $service)
+    public function createService($host, $service, $statesOverwrite)
     {
         $node = new ServiceNode(
             (object) array(
                 'hostname' => $host,
-                'service'  => $service
+                'service'  => $service,
+                'statesOverwrite'=> $statesOverwrite
             )
         );
         $node->setBpConfig($this);
-        $this->nodes[$host . ';' . $service] = $node;
+        $this->nodes[$host . ';' . $service.':'. $statesOverwrite] = $node;
         $this->hosts[$host] = true;
         return $node;
     }
@@ -648,13 +649,26 @@ class BpConfig
             if ($service === 'Hoststatus') {
                 return $this->createHost($host);
             } else {
-                return $this->createService($host, $service);
+                return $this->createService($host, $service, '');
             }
         }
 
         throw new Exception(
             sprintf('The node "%s" doesn\'t exist', $name)
         );
+    }
+    
+    public function getMatchingNodeNams($name) {
+        
+        $matching = array();
+        
+        foreach($this->nodes as $nodeName => $node ) {
+            if($name == $node->getShortName()) {
+                array_push($matching, $nodeName);
+            }                
+        }
+        
+        return $matching;
     }
 
     /**

--- a/library/Businessprocess/BpNode.php
+++ b/library/Businessprocess/BpNode.php
@@ -143,6 +143,11 @@ class BpNode extends Node
     {
         return in_array($name, $this->getChildNames());
     }
+    
+    public function hasMatchingChild($name)
+    {
+        return in_array($name, $this->getChildShortNames());
+    }
 
     public function removeChild($name)
     {
@@ -457,6 +462,20 @@ class BpNode extends Node
 
         return $this->children;
     }
+    
+    protected function getChildShortNames() {
+        
+        $ChidrenShortNames = array();
+        
+        foreach ($this->getChildren() as $child) {
+            $name = $child->getShortName();
+            array_push($ChidrenShortNames, $name);
+        }
+        
+        return $ChidrenShortNames;
+    }
+    
+    
 
     /**
      * Reorder this node's children, in case manual order is not applied

--- a/library/Businessprocess/Modification/NodeAddChildrenAction.php
+++ b/library/Businessprocess/Modification/NodeAddChildrenAction.php
@@ -31,15 +31,22 @@ class NodeAddChildrenAction extends NodeAction
     {
         $node = $config->getBpNode($this->getNodeName());
 
-        foreach ($this->children as $name) {
+        foreach ($this->children as $name) {           
+            $statesOverwrite = '';
+                                 
             if (! $config->hasNode($name) || $config->getNode($name)->getBpConfig()->getName() !== $config->getName()) {
                 if (strpos($name, ';') !== false) {
-                    list($host, $service) = preg_split('/;/', $name, 2);
+                    
+                    if(strpos($name, ':') !== false) {
+                        list($host, $service, $statesOverwrite) = preg_split('~[;:]~', $name, 3);
+                    } else {
+                        list($host, $service) = preg_split('/;/', $name, 2);
+                    }
 
                     if ($service === 'Hoststatus') {
                         $config->createHost($host);
                     } else {
-                        $config->createService($host, $service);
+                        $config->createService($host, $service, $statesOverwrite);
                     }
                 } elseif ($name[0] === '@' && strpos($name, ':') !== false) {
                     list($configName, $nodeName) = preg_split('~:\s*~', substr($name, 1), 2);

--- a/library/Businessprocess/Node.php
+++ b/library/Businessprocess/Node.php
@@ -37,6 +37,8 @@ abstract class Node
         self::ICINGA_WARNING  => 2,
         self::ICINGA_OK       => 0,
     );
+       
+    protected $stateOverwrite = array();
 
     /**
      * Main business process object
@@ -164,6 +166,26 @@ abstract class Node
         $this->missing = false;
         return $this;
     }
+    
+    protected function setStateOverwrite($state,$overWriteState) {
+        $this->stateOverwrite[(int) $state] = (int) $overWriteState;
+    }
+    
+    public function setStatesOverwrite($statesOverwriteString) {
+        
+        $overwrites = explode(',', $statesOverwriteString);
+        
+        foreach($overwrites as $overwriteState) {
+            if(strpos($overwriteState, '-') !== false) {
+                list($key, $value) = explode('-', $overwriteState);
+                $this->setStateOverwrite($key,$value);
+            }
+        }
+    }
+    
+    public function getStatesOverwrite() {
+        return $this->stateOverwrite;
+    }
 
     /**
      * Forget my state
@@ -202,7 +224,7 @@ abstract class Node
     {
         return $this->stateNames;
     }
-
+ 
     public function getState()
     {
         if ($this->state === null) {
@@ -213,7 +235,25 @@ abstract class Node
                 )
             );
         }
-
+      
+        if(isset($this->stateOverwrite[$this->state])) {
+            return $this->stateOverwrite[$this->state];
+        } else {
+            return $this->state;
+        }
+    }
+    
+    public function getRealState() 
+    {
+        if ($this->state === null) {
+            throw new ProgrammingError(
+                sprintf(
+                    'Node %s is unable to retrieve it\'s state',
+                    $this->name
+                    )
+                );
+        }
+        
         return $this->state;
     }
 
@@ -298,6 +338,11 @@ abstract class Node
     }
 
     public function getAlias()
+    {
+        return $this->name;
+    }
+    
+    public function getShortName()
     {
         return $this->name;
     }

--- a/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
+++ b/library/Businessprocess/Renderer/TileRenderer/NodeTile.php
@@ -99,6 +99,15 @@ class NodeTile extends BaseHtmlElement
         }
 
         $this->add($link);
+        
+        if($node instanceof ServiceNode && $node->getRealState() != $node->getState()) {
+            $this->add((new StateBall(strtolower($node->getStateName($node->getRealState()))))->addAttributes([
+                'title' => sprintf(
+                    '%s',
+                    $node->getStateName($node->getRealState())
+                    )
+            ]));  
+        }       
 
         if ($node instanceof BpNode && !$renderer->isBreadcrumb()) {
             $this->add(Html::tag(

--- a/library/Businessprocess/Renderer/TreeRenderer.php
+++ b/library/Businessprocess/Renderer/TreeRenderer.php
@@ -131,6 +131,47 @@ class TreeRenderer extends Renderer
         }
         return $icons;
     }
+    
+    public function getNodeRealState(Node $node) {
+        
+        $realState = [];               
+        $realState[] = Html::tag('i', ['class' => 'icon icon-flash']);
+        $realState[] = (new StateBall(strtolower($node->getStateName($node->getRealState()))))->addAttributes([
+            'title' => sprintf(
+                '%s',
+                $node->getStateName($node->getRealState())
+                )
+        ]);
+        
+        return $realState;
+    }
+    
+    public function getNodeStateOverwrite(Node $node) {
+        
+        $statesOverrights = [];
+        
+        $states = $node->getStatesOverwrite();
+        
+        foreach ($states as $originalState => $overwriteState) {
+                        
+            $statesOverrights[]=  (new StateBall(strtolower($node->getStateName($originalState))))->addAttributes([
+                'title' => sprintf(
+                    '%s',
+                    $node->getStateName($originalState)
+                    )
+            ]);
+            $statesOverrights[] = Html::tag('i', ['class' => 'icon icon-right-small']);
+            $statesOverrights[] = (new StateBall(strtolower($node->getStateName($overwriteState))))->addAttributes([
+                'title' => sprintf(
+                    '%s',
+                    $node->getStateName($overwriteState)
+                    ),
+                'class' => 'last'
+            ]);
+        }
+        
+        return $statesOverrights;
+    }
 
     /**
      * @param BpConfig $bp
@@ -238,11 +279,25 @@ class TreeRenderer extends Renderer
         $link = $node->getLink();
         $link->getAttributes()->set('data-base-target', '_next');
         $li->add($link);
-
-        if (! $this->isLocked() && $node->getBpConfig()->getName() === $this->getBusinessProcess()->getName()) {
-            $li->add($this->getActionIcons($bp, $node));
+        
+        if($node->getRealState() != $node->getState()) {
+            $li->add($this->getNodeRealState($node));
+        }
+        
+        $leftAlign = Html::tag('div', [
+            'class'             => 'left-side',
+        ]);
+        
+        if(!empty($node->getStatesOverwrite())) {
+            $leftAlign->add($this->getNodeStateOverwrite($node));
         }
 
+        if (! $this->isLocked() && $node->getBpConfig()->getName() === $this->getBusinessProcess()->getName()) {
+            $leftAlign->add($this->getActionIcons($bp, $node));
+        }
+        
+        $li->add($leftAlign);
+        
         return $li;
     }
 

--- a/library/Businessprocess/ServiceNode.php
+++ b/library/Businessprocess/ServiceNode.php
@@ -15,10 +15,11 @@ class ServiceNode extends MonitoredNode
     protected $icon = 'service';
 
     public function __construct($object)
-    {
-        $this->name = $object->hostname . ';' . $object->service;
+    {        
+        $this->name = $object->hostname . ';' . $object->service. ':'. $object->statesOverwrite;
         $this->hostname = $object->hostname;
         $this->service  = $object->service;
+        $this->setStatesOverwrite($object->statesOverwrite);
         if (isset($object->state)) {
             $this->setState($object->state);
         } else {
@@ -39,6 +40,11 @@ class ServiceNode extends MonitoredNode
     public function getAlias()
     {
         return $this->hostname . ': ' . $this->service;
+    }
+    
+    public function getShortName()
+    {
+        return $this->hostname . ';' . $this->service;
     }
 
     public function getUrl()

--- a/library/Businessprocess/State/MonitoringState.php
+++ b/library/Businessprocess/State/MonitoringState.php
@@ -117,25 +117,30 @@ class MonitoringState
         } else {
             $key .= ';Hoststatus';
         }
-
-        // We fetch more states than we need, so skip unknown ones
-        if (! $config->hasNode($key)) {
-            return;
-        }
-
-        $node = $config->getNode($key);
-
-        if ($row->state !== null) {
-            $node->setState($row->state)->setMissing(false);
-        }
-        if ($row->last_state_change !== null) {
-            $node->setLastStateChange($row->last_state_change);
-        }
-        if ((int) $row->in_downtime === 1) {
-            $node->setDowntime(true);
-        }
-        if ((int) $row->ack === 1) {
-            $node->setAck(true);
-        }
+        
+        $nodesNames = $config->getMatchingNodeNams($key);
+        
+        foreach($nodesNames as $nodeName) {
+            
+            // We fetch more states than we need, so skip unknown ones
+            if (! $config->hasNode($nodeName)) {
+                return;
+            }
+        
+            $node = $config->getNode($nodeName);
+        
+            if ($row->state !== null) {
+                $node->setState($row->state)->setMissing(false);
+            }
+            if ($row->last_state_change !== null) {
+                $node->setLastStateChange($row->last_state_change);
+            }
+            if ((int) $row->in_downtime === 1) {
+                $node->setDowntime(true);
+            }
+            if ((int) $row->ack === 1) {
+                $node->setAck(true);
+            }
+        }       
     }
 }

--- a/library/Businessprocess/Storage/LegacyConfigParser.php
+++ b/library/Businessprocess/Storage/LegacyConfigParser.php
@@ -335,11 +335,21 @@ class LegacyConfigParser
                 if ($bp->hasNode($val)) {
                     $node->addChild($bp->getNode($val));
                 } else {
-                    list($host, $service) = preg_split('~;~', $val, 2);
+                    $statesOverwrite = '';
+                    
+                    if(strpos($val, ':') !== false) {
+                        list($host, $service, $statesOverwrite) = preg_split('~[;:]~', $val, 3);
+                    } else {
+                        list($host, $service) = preg_split('~;~', $val, 2);
+                        
+                        if ($service !== 'Hoststatus') {
+                            $val .= ':'. $statesOverwrite;
+                        }
+                    }                   
                     if ($service === 'Hoststatus') {
                         $node->addChild($bp->createHost($host));
                     } else {
-                        $node->addChild($bp->createService($host, $service));
+                        $node->addChild($bp->createService($host, $service, $statesOverwrite));
                     }
                 }
             } elseif ($val[0] === '@') {

--- a/library/Businessprocess/Web/Form/Validator/NoDuplicateChildrenValidator.php
+++ b/library/Businessprocess/Web/Form/Validator/NoDuplicateChildrenValidator.php
@@ -40,7 +40,7 @@ class NoDuplicateChildrenValidator extends Zend_Validate_Abstract
         if ($this->parent === null) {
             $found = $this->bp->hasRootNode($value);
         } else {
-            $found = $this->parent->hasChild($value);
+            $found = $this->parent->hasMatchingChild($value);
         }
 
         if (! $found) {

--- a/public/css/module.less
+++ b/public/css/module.less
@@ -214,13 +214,13 @@ ul.bp {
         > * {
             margin-right: .5em;
         }
+        
+        a.action-link {
+        	margin-left: 20px;
+        }
 
-        > a.action-link {
-            margin-left: auto; // Let the first action link move everything to the right
-
-            & + a.action-link {
-                margin-left: 0; // But really only the first one
-            }
+        > .left-side {
+            margin-left: auto; // Left alligned Icons
         }
     }
 
@@ -261,13 +261,18 @@ ul.bp {
     }
 
     li.process > div > .state-ball,
-    li:not(.process) > .state-ball {
+    li:not(.process) > .state-ball,
+    div.left-side > .state-ball {
         border: .15em solid white;
 
         &.size-s {
             width: 7em/6em;
             height: 7em/6em;
             line-height: 7em/6em;
+        	
+        	&.last {
+        		margin-right: 10px;
+        	}
         }
     }
 }
@@ -415,6 +420,14 @@ td > a > .badges {
         margin: 0.5em;
         text-align: center;
         font-size: 0.5em;
+    }
+        
+	.state-ball {
+		position: absolute;
+		right: 0px;
+		bottom: 0px;
+		margin: 5px 5px 5px 5px;
+		border: 1px solid white;
     }
 
     > a {


### PR DESCRIPTION
This pull requests adds a State overwrite function to the business process.

every state that a service could have. can be translated in another service state in the business process

So you can decide for ex. to set the state of a service to warning in the business process if the state goes to critical

![1](https://user-images.githubusercontent.com/49369365/56041601-69bca300-5d39-11e9-9cad-f22babb9cb99.png)

In the Tile view you see the service with the translated state and a small circle showing the real state if differs

![2](https://user-images.githubusercontent.com/49369365/56041900-1f87f180-5d3a-11e9-9a00-d116cf2f6989.png)
![icingastate](https://user-images.githubusercontent.com/49369365/56041919-2b73b380-5d3a-11e9-8209-55d2f3d2f875.png)

In the Tree view you also see the translation state settings

![3](https://user-images.githubusercontent.com/49369365/56042034-6b3a9b00-5d3a-11e9-8815-a2d4d5b86b7d.png)

Please let me know if there are things that need to be changed.